### PR TITLE
fix: added missing `react-native-size-matters` in `package.json`

### DIFF
--- a/template/InnovatorRN/package.json
+++ b/template/InnovatorRN/package.json
@@ -18,10 +18,6 @@
     "appium": "appium",
     "appium:doctor": "appium-doctor"
   },
-  "lint-staged": {
-    "*.js": "lint:eslint"
-  },
-  "pre-commit": "lint:staged",
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.10",
@@ -37,6 +33,7 @@
     "react-native-reanimated": "^1.13.1",
     "react-native-safe-area-context": "^3.1.8",
     "react-native-screens": "^2.11.0",
+    "react-native-size-matters": "^0.4.0",
     "react-native-vector-icons": "^6.6.0",
     "react-redux": "^7.2.1"
   },


### PR DESCRIPTION
### Fixed Issues

The earlier PR https://github.com/uCreateit/react-native-innovator/pull/38 missed the `react-native-size-matters` dependency in the `package.json` file. This PR includes that missing dependency into the `package.json` file.

### Proposed Changes
<!-- Please mention the proposed changes in the PR -->

  - Added `react-native-size-matters` dependency into `package.json` file

### Tested On
<!-- Please make sure that you have tested the proposed changes on your local machine before making the PR -->

- [x] iOS
- [x] Android
